### PR TITLE
feat: add test case routes and sidebar link

### DIFF
--- a/src/layouts/AdminLayout.vue
+++ b/src/layouts/AdminLayout.vue
@@ -27,6 +27,10 @@
           <el-icon><Document /></el-icon>
           <span>用例看板</span>
         </el-menu-item>
+        <el-menu-item index="/cases" class="menu-item">
+          <el-icon><Document /></el-icon>
+          <span>用例管理</span>
+        </el-menu-item>
         <el-menu-item index="/users" class="menu-item">
           <el-icon><User /></el-icon>
           <span>用户管理</span>

--- a/src/pages/Cases/TestCaseDetailPage.vue
+++ b/src/pages/Cases/TestCaseDetailPage.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="test-case-detail-page">
+    用例详情
+  </div>
+</template>
+
+<script setup>
+// 用例详情页面
+</script>
+
+<style scoped>
+.test-case-detail-page {
+  padding: 20px;
+}
+</style>

--- a/src/pages/Cases/TestCaseManagePage.vue
+++ b/src/pages/Cases/TestCaseManagePage.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="test-case-manage-page">
+    用例管理
+  </div>
+</template>
+
+<script setup>
+// 用例管理页面，包含列表和树结构
+</script>
+
+<style scoped>
+.test-case-manage-page {
+  padding: 20px;
+}
+</style>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -22,6 +22,18 @@ export const routes = [
         meta: { title: '用例看板' }
       },
       {
+        path: 'cases',
+        name: 'caseManage',
+        component: () => import('../pages/Cases/TestCaseManagePage.vue'),
+        meta: { title: '用例管理' }
+      },
+      {
+        path: '/cases/:id',
+        name: 'caseDetail',
+        component: () => import('../pages/Cases/TestCaseDetailPage.vue'),
+        meta: { title: '用例详情' }
+      },
+      {
         path: 'users',
         name: 'userManage',
         component: () => import('../pages/Users/UserManagePage.vue'),


### PR DESCRIPTION
## Summary
- add test case management and detail routes
- add sidebar entry for test case management
- stub pages for test case management and detail views

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c24bbfaf108331b4358c65e96a773c