### PR TITLE
feat: add test case management pages

### DIFF
--- a/src/api/testCases.js
+++ b/src/api/testCases.js
@@ -1,0 +1,63 @@
+// ================== src/api/testCases.js ==================
+import http from './http'
+import { ElMessage } from 'element-plus'
+
+async function handleRequest(apiFunc, args = [], defaultErrorMsg = '操作失败') {
+  try {
+    const response = await apiFunc(...args)
+    const data = response.data
+    if (data.code !== undefined && data.code !== 200) {
+      ElMessage.error(data.message || defaultErrorMsg)
+      return { success: false, message: data.message || defaultErrorMsg, data: null, code: data.code }
+    }
+    return { success: true, data: data.data, message: data.message || '', code: data.code || 200 }
+  } catch (error) {
+    const errorMsg = error.response?.data?.message || error.message || defaultErrorMsg
+    ElMessage.error(errorMsg)
+    return { success: false, message: errorMsg, data: null }
+  }
+}
+
+// 基础接口
+function getTestCaseList(params = {}) {
+  return http.get('/api/test-cases', { params })
+}
+function getTestCase(id) {
+  return http.get(`/api/test-cases/${id}`)
+}
+function createTestCase(payload) {
+  return http.post('/api/test-cases', payload)
+}
+function updateTestCase(id, payload) {
+  return http.put(`/api/test-cases/${id}`, payload)
+}
+function copyTestCase(id, payload) {
+  return http.post(`/api/test-cases/${id}/copy`, payload)
+}
+function deleteTestCase(id) {
+  return http.delete(`/api/test-cases/${id}`)
+}
+function restoreTestCase(id) {
+  return http.post(`/api/test-cases/${id}/restore`)
+}
+function getTestCaseHistory(id) {
+  return http.get(`/api/test-cases/${id}/history`)
+}
+function getCaseGroups() {
+  return http.get('/api/test-cases/groups')
+}
+
+export const testCaseService = {
+  list: (params) => handleRequest(getTestCaseList, [params], '获取用例列表失败'),
+  get: (id) => handleRequest(getTestCase, [id], '获取用例详情失败'),
+  create: (payload) => handleRequest(createTestCase, [payload], '创建用例失败'),
+  update: (id, payload) => handleRequest(updateTestCase, [id, payload], '更新用例失败'),
+  copy: (id, payload) => handleRequest(copyTestCase, [id, payload], '复制用例失败'),
+  delete: (id) => handleRequest(deleteTestCase, [id], '删除用例失败'),
+  restore: (id) => handleRequest(restoreTestCase, [id], '恢复用例失败'),
+  history: (id) => handleRequest(getTestCaseHistory, [id], '获取用例历史失败'),
+  groups: () => handleRequest(getCaseGroups, [], '获取用例分组失败')
+}
+
+export default testCaseService
+

--- a/src/pages/TestCases/TestCaseDetailPage.vue
+++ b/src/pages/TestCases/TestCaseDetailPage.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="test-case-detail-page" v-if="caseData">
+    <el-card>
+      <h2>{{ caseData.title }}</h2>
+      <p><strong>前置条件：</strong>{{ caseData.preconditions }}</p>
+      <p><strong>步骤：</strong>{{ caseData.steps }}</p>
+      <p><strong>预期结果：</strong>{{ caseData.expected_result }}</p>
+      <p><strong>关键词：</strong>{{ caseData.keywords }}</p>
+      <p><strong>优先级：</strong>{{ caseData.priority }}</p>
+      <p><strong>类型：</strong>{{ caseData.case_type }}</p>
+      <p><strong>工作量：</strong>{{ caseData.workload_minutes }} 分钟</p>
+    </el-card>
+    <div class="actions">
+      <el-button type="primary" @click="handleEdit">编辑</el-button>
+      <el-button @click="handleCopy">复制</el-button>
+      <el-button type="danger" @click="handleDelete">删除</el-button>
+      <el-button @click="handleRestore">恢复</el-button>
+      <el-button @click="handleHistory">历史</el-button>
+    </div>
+    <test-case-form ref="formRef" @success="fetchCase" />
+    <test-case-history ref="historyRef" />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { testCaseService } from '@/api/testCases'
+import TestCaseForm from './components/TestCaseForm.vue'
+import TestCaseHistory from './components/TestCaseHistory.vue'
+
+const route = useRoute()
+const router = useRouter()
+const caseData = ref(null)
+
+const formRef = ref()
+const historyRef = ref()
+
+const fetchCase = async () => {
+  const id = route.params.id
+  const resp = await testCaseService.get(id)
+  if (resp.success) {
+    caseData.value = resp.data
+  }
+}
+
+const handleEdit = () => formRef.value?.open('edit', caseData.value)
+const handleCopy = () => formRef.value?.open('copy', caseData.value)
+const handleDelete = async () => {
+  const resp = await testCaseService.delete(caseData.value.id)
+  if (resp.success) {
+    router.back()
+  }
+}
+const handleRestore = async () => {
+  const resp = await testCaseService.restore(caseData.value.id)
+  if (resp.success) {
+    fetchCase()
+  }
+}
+const handleHistory = () => {
+  historyRef.value?.open(caseData.value.id)
+}
+
+onMounted(fetchCase)
+</script>
+
+<style scoped>
+.test-case-detail-page {
+  padding: 20px;
+}
+.actions {
+  margin-top: 20px;
+}
+.actions .el-button {
+  margin-right: 10px;
+}
+</style>

--- a/src/pages/TestCases/TestCaseManagePage.vue
+++ b/src/pages/TestCases/TestCaseManagePage.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="test-case-manage-page">
+    <div class="layout">
+      <div class="group-tree">
+        <case-group-tree @select="handleGroupSelect" />
+      </div>
+      <div class="case-table">
+        <div class="toolbar">
+          <el-input
+            v-model="filters.keyword"
+            placeholder="搜索标题"
+            clearable
+            style="width: 200px; margin-right: 10px"
+            @keyup.enter="fetchCases"
+          />
+          <el-button type="primary" @click="fetchCases" style="margin-right: 10px">搜索</el-button>
+          <el-button type="primary" @click="handleCreate">
+            <el-icon><Plus /></el-icon>
+            新建用例
+          </el-button>
+        </div>
+        <test-case-table
+          :cases="caseList"
+          :loading="loading"
+          @edit="handleEdit"
+          @copy="handleCopy"
+          @delete="handleDelete"
+          @history="handleHistory"
+          @view="handleView"
+        />
+      </div>
+    </div>
+    <test-case-form ref="formRef" @success="handleRefresh" />
+    <test-case-history ref="historyRef" />
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { Plus } from '@element-plus/icons-vue'
+import CaseGroupTree from './components/CaseGroupTree.vue'
+import TestCaseTable from './components/TestCaseTable.vue'
+import TestCaseForm from './components/TestCaseForm.vue'
+import TestCaseHistory from './components/TestCaseHistory.vue'
+import { testCaseService } from '@/api/testCases'
+
+const router = useRouter()
+
+const filters = ref({
+  group_id: null,
+  keyword: ''
+})
+const loading = ref(false)
+const caseList = ref([])
+
+const formRef = ref()
+const historyRef = ref()
+
+const fetchCases = async () => {
+  loading.value = true
+  try {
+    const resp = await testCaseService.list(filters.value)
+    if (resp.success) {
+      caseList.value = resp.data || []
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+const handleGroupSelect = (id) => {
+  filters.value.group_id = id
+  fetchCases()
+}
+
+const handleCreate = () => {
+  formRef.value?.open('create')
+}
+const handleEdit = (row) => {
+  formRef.value?.open('edit', row)
+}
+const handleCopy = (row) => {
+  formRef.value?.open('copy', row)
+}
+const handleDelete = async (row) => {
+  const resp = await testCaseService.delete(row.id)
+  if (resp.success) {
+    fetchCases()
+  }
+}
+const handleHistory = (row) => {
+  historyRef.value?.open(row.id)
+}
+const handleView = (row) => {
+  router.push({ name: 'TestCaseDetail', params: { id: row.id } })
+}
+const handleRefresh = () => {
+  fetchCases()
+}
+
+onMounted(fetchCases)
+</script>
+
+<style scoped>
+.test-case-manage-page {
+  padding: 20px;
+  background: #f5f7fa;
+  min-height: 100vh;
+}
+.layout {
+  display: flex;
+}
+.group-tree {
+  width: 250px;
+  margin-right: 20px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.case-table {
+  flex: 1;
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.toolbar {
+  margin-bottom: 20px;
+}
+</style>

--- a/src/pages/TestCases/components/CaseGroupTree.vue
+++ b/src/pages/TestCases/components/CaseGroupTree.vue
@@ -1,0 +1,33 @@
+<template>
+  <el-tree
+    :data="groups"
+    node-key="id"
+    :props="treeProps"
+    highlight-current
+    default-expand-all
+    @node-click="handleSelect"
+  />
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { testCaseService } from '@/api/testCases'
+
+const emit = defineEmits(['select'])
+
+const groups = ref([])
+const treeProps = { label: 'name', children: 'children' }
+
+const fetchGroups = async () => {
+  const resp = await testCaseService.groups()
+  if (resp.success) {
+    groups.value = resp.data || []
+  }
+}
+
+const handleSelect = (data) => {
+  emit('select', data.id)
+}
+
+onMounted(fetchGroups)
+</script>

--- a/src/pages/TestCases/components/TestCaseForm.vue
+++ b/src/pages/TestCases/components/TestCaseForm.vue
@@ -1,0 +1,128 @@
+<template>
+  <el-dialog v-model="visible" :title="dialogTitle" width="600px">
+    <el-form :model="form" label-width="100px">
+      <el-form-item label="标题">
+        <el-input v-model="form.title" />
+      </el-form-item>
+      <el-form-item label="前置条件">
+        <el-input type="textarea" v-model="form.preconditions" />
+      </el-form-item>
+      <el-form-item label="步骤">
+        <el-input type="textarea" v-model="form.steps" />
+      </el-form-item>
+      <el-form-item label="预期结果">
+        <el-input type="textarea" v-model="form.expected_result" />
+      </el-form-item>
+      <el-form-item label="关键词">
+        <el-input v-model="form.keywords" />
+      </el-form-item>
+      <el-form-item label="优先级">
+        <el-select v-model="form.priority" placeholder="请选择">
+          <el-option v-for="opt in priorityOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="用例类型">
+        <el-select v-model="form.case_type" placeholder="请选择">
+          <el-option v-for="opt in typeOptions" :key="opt.value" :label="opt.label" :value="opt.value" />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="所属分组">
+        <el-select v-model="form.group_id" placeholder="请选择">
+          <el-option v-for="g in groupOptions" :key="g.id" :label="g.name" :value="g.id" />
+        </el-select>
+      </el-form-item>
+      <el-form-item label="工作量(分钟)">
+        <el-input-number v-model="form.workload_minutes" :min="0" />
+      </el-form-item>
+    </el-form>
+    <template #footer>
+      <el-button @click="visible = false">取消</el-button>
+      <el-button type="primary" @click="handleSubmit">确定</el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { ElMessage } from 'element-plus'
+import { testCaseService } from '@/api/testCases'
+
+const visible = ref(false)
+const mode = ref('create')
+
+const form = ref({
+  id: null,
+  title: '',
+  preconditions: '',
+  steps: '',
+  expected_result: '',
+  keywords: '',
+  priority: '',
+  case_type: '',
+  group_id: null,
+  workload_minutes: 0
+})
+
+const priorityOptions = [
+  { label: '高', value: 'high' },
+  { label: '中', value: 'medium' },
+  { label: '低', value: 'low' }
+]
+const typeOptions = [
+  { label: '功能', value: 'functional' },
+  { label: '性能', value: 'performance' }
+]
+const groupOptions = ref([])
+
+const emit = defineEmits(['success'])
+
+const dialogTitle = computed(() => {
+  if (mode.value === 'edit') return '编辑用例'
+  if (mode.value === 'copy') return '复制用例'
+  return '新建用例'
+})
+
+const loadGroups = async () => {
+  const resp = await testCaseService.groups()
+  if (resp.success) {
+    groupOptions.value = resp.data || []
+  }
+}
+
+const open = (m = 'create', data = null) => {
+  mode.value = m
+  visible.value = true
+  form.value = {
+    id: data?.id || null,
+    title: data?.title || '',
+    preconditions: data?.preconditions || '',
+    steps: data?.steps || '',
+    expected_result: data?.expected_result || '',
+    keywords: data?.keywords || '',
+    priority: data?.priority || '',
+    case_type: data?.case_type || '',
+    group_id: data?.group_id || null,
+    workload_minutes: data?.workload_minutes || 0
+  }
+  loadGroups()
+}
+
+const handleSubmit = async () => {
+  let resp
+  const payload = { ...form.value }
+  if (mode.value === 'edit') {
+    resp = await testCaseService.update(form.value.id, payload)
+  } else if (mode.value === 'copy') {
+    resp = await testCaseService.copy(form.value.id, payload)
+  } else {
+    resp = await testCaseService.create(payload)
+  }
+  if (resp.success) {
+    ElMessage.success('操作成功')
+    visible.value = false
+    emit('success')
+  }
+}
+
+defineExpose({ open })
+</script>

--- a/src/pages/TestCases/components/TestCaseHistory.vue
+++ b/src/pages/TestCases/components/TestCaseHistory.vue
@@ -1,0 +1,33 @@
+<template>
+  <el-drawer v-model="visible" title="历史记录" size="40%">
+    <el-timeline>
+      <el-timeline-item
+        v-for="item in records"
+        :key="item.id"
+        :timestamp="item.created_at"
+      >
+        {{ item.action }}
+      </el-timeline-item>
+    </el-timeline>
+  </el-drawer>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { testCaseService } from '@/api/testCases'
+
+const visible = ref(false)
+const records = ref([])
+
+const open = async (id) => {
+  visible.value = true
+  const resp = await testCaseService.history(id)
+  if (resp.success) {
+    records.value = resp.data || []
+  } else {
+    records.value = []
+  }
+}
+
+defineExpose({ open })
+</script>

--- a/src/pages/TestCases/components/TestCaseTable.vue
+++ b/src/pages/TestCases/components/TestCaseTable.vue
@@ -1,0 +1,28 @@
+<template>
+  <el-table :data="cases" v-loading="loading" style="width: 100%">
+    <el-table-column prop="id" label="ID" width="80" />
+    <el-table-column prop="title" label="标题" min-width="200">
+      <template #default="{ row }">
+        <el-link type="primary" @click="$emit('view', row)">{{ row.title }}</el-link>
+      </template>
+    </el-table-column>
+    <el-table-column prop="priority" label="优先级" width="100" />
+    <el-table-column label="操作" width="260">
+      <template #default="{ row }">
+        <el-button type="primary" link size="small" @click="$emit('edit', row)">编辑</el-button>
+        <el-button type="primary" link size="small" @click="$emit('copy', row)">复制</el-button>
+        <el-button type="primary" link size="small" @click="$emit('history', row)">历史</el-button>
+        <el-button type="danger" link size="small" @click="$emit('delete', row)">删除</el-button>
+      </template>
+    </el-table-column>
+  </el-table>
+</template>
+
+<script setup>
+defineProps({
+  cases: { type: Array, default: () => [] },
+  loading: Boolean
+})
+
+defineEmits(['edit', 'copy', 'delete', 'history', 'view'])
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -42,6 +42,24 @@ export const routes = [
         },
       },
       {
+        path: 'test-cases',
+        name: 'TestCaseManage',
+        component: () => import('../pages/TestCases/TestCaseManagePage.vue'),
+        meta: {
+          title: '用例管理',
+          requiresAuth: true
+        }
+      },
+      {
+        path: 'test-cases/:id',
+        name: 'TestCaseDetail',
+        component: () => import('../pages/TestCases/TestCaseDetailPage.vue'),
+        meta: {
+          title: '用例详情',
+          requiresAuth: true
+        }
+      },
+      {
         path: '/departments/:id',
         name: 'DepartmentDetail',
         component: () => import('../pages/Departments/DepartmentDetail.vue'),


### PR DESCRIPTION
## Summary
- add test case service for CRUD, copy, history and groups
- create TestCaseManagePage combining group tree and case table
- add reusable TestCaseForm and history drawer plus detail page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c24bc3e6088331b1e59db5ae1cafcf