### PR TITLE
feat: add test case store and components

### DIFF
--- a/src/components/Cases/CaseGroupTree.vue
+++ b/src/components/Cases/CaseGroupTree.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="case-group-tree">
+    <el-tree
+      :data="treeData"
+      node-key="id"
+      :highlight-current="true"
+      :default-expanded-keys="expandedKeys"
+      @node-click="handleNodeClick"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { useTestCasesStore } from '@/stores/modules/testCases'
+
+const testCasesStore = useTestCasesStore()
+
+// mock tree data, normally fetched from API
+const treeData = ref([
+  {
+    id: 1,
+    label: '部门A',
+    children: [
+      { id: 11, label: '分组1', departmentId: 1 },
+      { id: 12, label: '分组2', departmentId: 1 }
+    ]
+  },
+  {
+    id: 2,
+    label: '部门B',
+    children: [
+      { id: 21, label: '分组3', departmentId: 2 }
+    ]
+  }
+])
+
+const expandedKeys = ref([1, 2])
+
+const handleNodeClick = (node) => {
+  const departmentId = node.departmentId || node.id
+  const groupId = node.children ? null : node.id
+  testCasesStore.changeGroup({ departmentId, groupId })
+}
+
+// keep tree selection in sync with store
+watch(
+  () => testCasesStore.selectedGroupId,
+  (id) => {
+    if (id) {
+      expandedKeys.value = [testCasesStore.selectedDepartmentId]
+    }
+  }
+)
+</script>
+
+<style scoped>
+.case-group-tree {
+  background: #fff;
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+</style>

--- a/src/components/Cases/TestCaseTable.vue
+++ b/src/components/Cases/TestCaseTable.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="test-case-table">
+    <div class="filter-bar">
+      <el-input
+        v-model="localFilters.keyword"
+        placeholder="搜索关键字"
+        style="width: 200px"
+        @keyup.enter="applyFilters"
+      />
+      <el-select v-model="localFilters.status" placeholder="状态" style="width: 140px" clearable>
+        <el-option label="全部" value="" />
+        <el-option label="通过" value="passed" />
+        <el-option label="失败" value="failed" />
+      </el-select>
+      <el-button type="primary" @click="applyFilters">搜索</el-button>
+      <el-button @click="reset">重置</el-button>
+    </div>
+
+    <div class="selected-info">
+      当前部门: {{ testCasesStore.selectedDepartmentId }}<br />
+      当前分组: {{ testCasesStore.selectedGroupId }}
+    </div>
+
+    <!-- 用例表格（示例） -->
+    <el-table :data="[]" style="width: 100%">
+      <el-table-column label="用例名称" />
+    </el-table>
+
+    <el-pagination
+      class="pagination"
+      background
+      layout="prev, pager, next"
+      v-model:current-page="testCasesStore.pagination.page"
+      v-model:page-size="testCasesStore.pagination.pageSize"
+      :total="testCasesStore.pagination.total"
+    />
+  </div>
+</template>
+
+<script setup>
+import { reactive } from 'vue'
+import { useTestCasesStore } from '@/stores/modules/testCases'
+
+const testCasesStore = useTestCasesStore()
+const localFilters = reactive({ ...testCasesStore.filters })
+
+const applyFilters = () => {
+  testCasesStore.setFilters(localFilters)
+}
+
+const reset = () => {
+  Object.assign(localFilters, { keyword: '', creator: '', status: '' })
+  testCasesStore.resetState()
+}
+</script>
+
+<style scoped>
+.test-case-table {
+  background: #fff;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.filter-bar {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+.selected-info {
+  margin-bottom: 16px;
+  color: #666;
+}
+.pagination {
+  margin-top: 16px;
+  text-align: center;
+}
+</style>

--- a/src/pages/Cases/TestCaseManagePage.vue
+++ b/src/pages/Cases/TestCaseManagePage.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="test-case-manage-page">
+    <div class="group-tree-wrapper">
+      <CaseGroupTree />
+    </div>
+    <div class="table-wrapper">
+      <TestCaseTable />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import CaseGroupTree from '@/components/Cases/CaseGroupTree.vue'
+import TestCaseTable from '@/components/Cases/TestCaseTable.vue'
+import { useTestCasesStore } from '@/stores/modules/testCases'
+import { onBeforeUnmount } from 'vue'
+
+const testCasesStore = useTestCasesStore()
+
+// reset store when leaving page to avoid stale state
+onBeforeUnmount(() => {
+  testCasesStore.resetState()
+})
+</script>
+
+<style scoped>
+.test-case-manage-page {
+  display: flex;
+  gap: 16px;
+  padding: 20px;
+  background: #f5f7fa;
+  min-height: 100vh;
+}
+.group-tree-wrapper {
+  width: 240px;
+}
+.table-wrapper {
+  flex: 1;
+}
+</style>

--- a/src/stores/modules/testCases.js
+++ b/src/stores/modules/testCases.js
@@ -1,0 +1,52 @@
+import { defineStore } from 'pinia'
+import { ref, reactive } from 'vue'
+
+// Store for managing test case selection, filters and pagination
+export const useTestCasesStore = defineStore('testCases', () => {
+  // currently selected department and group
+  const selectedDepartmentId = ref(null)
+  const selectedGroupId = ref(null)
+
+  // filter fields for querying test cases
+  const filters = reactive({
+    keyword: '',
+    creator: '',
+    status: ''
+  })
+
+  // pagination information
+  const pagination = reactive({
+    page: 1,
+    pageSize: 10,
+    total: 0
+  })
+
+  // actions
+  const setFilters = (newFilters = {}) => {
+    Object.assign(filters, newFilters)
+  }
+
+  const changeGroup = ({ departmentId = null, groupId = null } = {}) => {
+    selectedDepartmentId.value = departmentId
+    selectedGroupId.value = groupId
+  }
+
+  const resetState = () => {
+    selectedDepartmentId.value = null
+    selectedGroupId.value = null
+    Object.assign(filters, { keyword: '', creator: '', status: '' })
+    Object.assign(pagination, { page: 1, pageSize: 10, total: 0 })
+  }
+
+  return {
+    // getters / state
+    selectedDepartmentId,
+    selectedGroupId,
+    filters,
+    pagination,
+    // actions
+    setFilters,
+    changeGroup,
+    resetState
+  }
+})


### PR DESCRIPTION
## Summary
- add test case Pinia store for groups, filters and pagination
- create test case management page with group tree and table
- sync selected group and filters across components

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c24bc7769883318b92252865e5ffeb