### PR TITLE
feat: enhance case group management

### DIFF
--- a/src/pages/TestCases/TestCaseManagePage.vue
+++ b/src/pages/TestCases/TestCaseManagePage.vue
@@ -17,7 +17,7 @@
     </div>
     <div class="layout">
       <div class="group-tree">
-        <case-group-tree :department-id="departmentId" @select="handleGroupSelect" />
+        <case-group-tree ref="groupTreeRef" :department-id="departmentId" @select="handleGroupSelect" />
       </div>
       <div class="case-table">
         <div class="toolbar">
@@ -80,7 +80,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, reactive } from 'vue'
 import { Plus } from '@element-plus/icons-vue'
 import { ElMessageBox } from 'element-plus'
 import CaseGroupTree from './components/CaseGroupTree.vue'
@@ -96,7 +96,7 @@ import {
   TEST_CASE_STATUS_OPTIONS
 } from '@/constants/testCase'
 
-const filters = ref({
+const filters = reactive({
   title: '',
   status: '',
   priority: '',
@@ -108,6 +108,7 @@ const loading = ref(false)
 const caseList = ref([])
 const departments = ref([])
 const departmentId = ref(null)
+const groupTreeRef = ref()
 
 const page = ref(1)
 const pageSize = ref(20)
@@ -125,14 +126,14 @@ const fetchCases = async () => {
   if (!departmentId.value) return
   loading.value = true
   try {
-    const kw = parseKeywords(filters.value.keywords)
+    const kw = parseKeywords(filters.keywords)
     const params = {
-      title: filters.value.title,
-      status: filters.value.status,
-      priority: filters.value.priority,
-      case_type: filters.value.case_type,
+      title: filters.title,
+      status: filters.status,
+      priority: filters.priority,
+      case_type: filters.case_type,
       keywords: kw.length ? kw : undefined,
-      group_id: filters.value.group_id,
+      group_id: filters.group_id,
       page: page.value,
       page_size: pageSize.value
     }
@@ -147,7 +148,7 @@ const fetchCases = async () => {
 }
 
 const handleGroupSelect = (id) => {
-  filters.value.group_id = id
+  filters.group_id = id
   page.value = 1
   fetchCases()
 }
@@ -164,24 +165,9 @@ const fetchDepartments = async () => {
 }
 
 const handleDeptChange = () => {
-  filters.value.group_id = null
+  filters.group_id = null
+  groupTreeRef.value?.clearSelection()
   page.value = 1
-  fetchCases()
-}
-
-const fetchDepartments = async () => {
-  const resp = await departmentService.list()
-  if (resp.success) {
-    departments.value = resp.data?.items || []
-    if (departments.value.length && !departmentId.value) {
-      departmentId.value = departments.value[0].id
-      fetchCases()
-    }
-  }
-}
-
-const handleDeptChange = () => {
-  filters.value.group_id = null
   fetchCases()
 }
 
@@ -215,11 +201,15 @@ const handleSearch = () => {
   fetchCases()
 }
 const handleReset = () => {
-  filters.value.title = ''
-  filters.value.status = ''
-  filters.value.priority = ''
-  filters.value.case_type = ''
-  filters.value.keywords = ''
+  Object.assign(filters, {
+    title: '',
+    status: '',
+    priority: '',
+    case_type: '',
+    keywords: '',
+    group_id: null
+  })
+  groupTreeRef.value?.clearSelection()
   page.value = 1
   fetchCases()
 }

--- a/src/pages/TestCases/components/CaseGroupTree.vue
+++ b/src/pages/TestCases/components/CaseGroupTree.vue
@@ -1,17 +1,30 @@
 
 <template>
-  <el-tree
-    :data="groups"
-    node-key="id"
-    :props="treeProps"
-    highlight-current
-    default-expand-all
-    @node-click="handleSelect"
-  />
+  <div class="case-group-tree">
+    <div class="group-actions">
+      <el-button size="small" @click="handleAdd">新增</el-button>
+      <el-button size="small" :disabled="!currentId" @click="handleRename">修改</el-button>
+      <el-button size="small" :disabled="!currentId" @click="handleCopy">复制</el-button>
+      <el-button size="small" type="danger" :disabled="!currentId" @click="handleDelete">删除</el-button>
+    </div>
+    <el-tree
+      ref="treeRef"
+      :data="groups"
+      node-key="id"
+      :props="treeProps"
+      highlight-current
+      default-expand-all
+      draggable
+      :allow-drop="allowDrop"
+      @node-click="handleSelect"
+      @node-drop="handleDrop"
+    />
+  </div>
 </template>
 
 <script setup>
 import { ref, watch, onMounted } from 'vue'
+import { ElMessageBox } from 'element-plus'
 import { caseGroupService } from '@/api/caseGroups'
 
 const emit = defineEmits(['select'])
@@ -20,6 +33,8 @@ const props = defineProps({
 })
 
 const groups = ref([])
+const treeRef = ref()
+const currentId = ref(null)
 const treeProps = { label: 'name', children: 'children' }
 
 const fetchGroups = async () => {
@@ -35,9 +50,105 @@ const fetchGroups = async () => {
 }
 
 const handleSelect = (data) => {
+  currentId.value = data.id
   emit('select', data.id)
 }
 
+const clearSelection = () => {
+  currentId.value = null
+  treeRef.value?.setCurrentKey(null)
+}
+
+const handleAdd = async () => {
+  try {
+    const { value } = await ElMessageBox.prompt('请输入分组名称', '新增分组', {
+      inputValidator: v => !!v || '名称不能为空'
+    })
+    const payload = {
+      name: value,
+      department_id: props.departmentId,
+      parent_id: currentId.value
+    }
+    const resp = await caseGroupService.create(payload)
+    if (resp.success) {
+      await fetchGroups()
+    }
+  } catch {}
+}
+
+const handleRename = async () => {
+  if (!currentId.value) return
+  const node = treeRef.value.getCurrentNode()
+  try {
+    const { value } = await ElMessageBox.prompt('请输入新的分组名称', '修改分组', {
+      inputValue: node.name,
+      inputValidator: v => !!v || '名称不能为空'
+    })
+    const resp = await caseGroupService.update(currentId.value, { name: value })
+    if (resp.success) {
+      await fetchGroups()
+    }
+  } catch {}
+}
+
+const handleDelete = async () => {
+  if (!currentId.value) return
+  try {
+    await ElMessageBox.confirm('确认删除该分组吗？', '提示', { type: 'warning' })
+    const resp = await caseGroupService.delete(currentId.value)
+    if (resp.success) {
+      await fetchGroups()
+      clearSelection()
+    }
+  } catch {}
+}
+
+const handleCopy = async () => {
+  if (!currentId.value) return
+  const node = treeRef.value.getCurrentNode()
+  try {
+    const { value } = await ElMessageBox.prompt('请输入新分组名称', '复制分组', {
+      inputValidator: v => !!v || '名称不能为空'
+    })
+    const parentNode = treeRef.value.getNode(currentId.value)?.parent
+    const payload = {
+      name: value,
+      parent_id: parentNode ? parentNode.data.id : null
+    }
+    const resp = await caseGroupService.copy(currentId.value, payload)
+    if (resp.success) {
+      await fetchGroups()
+    }
+  } catch {}
+}
+
+const allowDrop = () => true
+
+const handleDrop = async (draggingNode, dropNode, type) => {
+  const parentId = type === 'inner' ? dropNode.data.id : dropNode.parent?.data?.id || null
+  const resp = await caseGroupService.update(draggingNode.data.id, { parent_id: parentId })
+  if (resp.success) {
+    await fetchGroups()
+  }
+}
+
 onMounted(fetchGroups)
-watch(() => props.departmentId, fetchGroups)
+watch(() => props.departmentId, () => {
+  clearSelection()
+  fetchGroups()
+})
+
+defineExpose({ clearSelection })
 </script>
+
+<style scoped>
+.el-tree-node.is-current > .el-tree-node__content {
+  background-color: #409eff;
+  color: #fff;
+}
+.group-actions {
+  margin-bottom: 10px;
+  display: flex;
+  gap: 4px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add full case group operations with drag-and-drop
- reset filters including groups and show selected values correctly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c28d6f5c04833189b824fd14af1491