### PR TITLE
fix: improve test case list display

### DIFF
--- a/src/pages/TestCases/TestCaseManagePage.vue
+++ b/src/pages/TestCases/TestCaseManagePage.vue
@@ -372,7 +372,7 @@ onMounted(() => {
 .layout {
   display: flex;
   gap: 24px;
-  height: calc(100vh - 200px);
+  align-items: flex-start;
 }
 
 .group-tree {
@@ -381,7 +381,6 @@ onMounted(() => {
   border-radius: 12px;
   padding: 20px;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
   display: flex;
   flex-direction: column;
 }

--- a/src/pages/TestCases/components/TestCaseTable.vue
+++ b/src/pages/TestCases/components/TestCaseTable.vue
@@ -38,7 +38,11 @@
         </template>
       </el-table-column>
 
-      <el-table-column prop="case_type" label="类型" width="100" align="center" />
+      <el-table-column label="类型" width="100" align="center">
+        <template #default="{ row }">
+          {{ TEST_CASE_TYPE_LABEL_MAP[row.case_type] || '-' }}
+        </template>
+      </el-table-column>
 
       <el-table-column label="更新人 / 时间" min-width="180">
         <template #default="{ row }">
@@ -46,7 +50,7 @@
             <div class="username">{{ row.updated_by || row.created_by || '-' }}</div>
             <div class="time-info">
               <el-icon><Timer /></el-icon>
-              <span class="time-text">{{ row.updated_at || row.created_at || '-' }}</span>
+              <span class="time-text">{{ formatDateTime(row.updated_at || row.created_at) || '-' }}</span>
             </div>
           </div>
         </template>
@@ -87,6 +91,8 @@
 
 <script setup>
 import { Document, Edit, Delete, Plus, Clock, Timer, DocumentCopy } from '@element-plus/icons-vue'
+import { TEST_CASE_TYPE_LABEL_MAP } from '@/constants/testCase'
+import { formatDateTime } from '@/utils/format'
 defineProps({
   cases: { type: Array, default: () => [] },
   loading: { type: Boolean, default: false }


### PR DESCRIPTION
## Summary
- map test case type values to project constants
- format updated time in case table
- remove fixed layout height to better accommodate paginated lists

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c78bec1fcc83318bc6968ba05625c3