### PR TITLE
feat: add project management module

### DIFF
--- a/src/api/projects.js
+++ b/src/api/projects.js
@@ -1,9 +1,101 @@
 import http from './http'
+import { ElMessage } from 'element-plus'
 
-// 获取项目列表
-export const projectsApi = {
-  // 获取用户的项目列表
-  getProjectNames(userId) {
-    return http.get(`/get_project_names/${userId}`)
+const BASE_URL = '/api/projects'
+
+/**
+ * 统一请求包装，保持与其他模块一致的返回结构
+ * @param {Function} apiFunc axios 请求函数
+ * @param {Array} args 参数数组
+ * @param {string} defaultErrorMsg 默认错误提示
+ */
+async function handleRequest(apiFunc, args = [], defaultErrorMsg = '操作失败') {
+  try {
+    const response = await apiFunc(...args)
+    const payload = response.data || {}
+
+    if (payload.code !== undefined && payload.code !== 200) {
+      ElMessage.error(payload.message || defaultErrorMsg)
+      return {
+        success: false,
+        message: payload.message || defaultErrorMsg,
+        data: payload.data ?? null,
+        code: payload.code
+      }
+    }
+
+    return {
+      success: true,
+      data: payload.data,
+      message: payload.message || '',
+      code: payload.code || 200
+    }
+  } catch (error) {
+    const errorMsg = error.response?.data?.message || error.message || defaultErrorMsg
+    ElMessage.error(errorMsg)
+    return { success: false, message: errorMsg, data: null }
   }
 }
+
+// 基础 REST API 请求函数
+const getProjectNames = (userId) => http.get(`/get_project_names/${userId}`)
+const listProjects = (params = {}) => http.get(BASE_URL, { params })
+const getProject = (projectId) => http.get(`${BASE_URL}/${projectId}`)
+const createProject = (payload) => http.post(BASE_URL, payload)
+const updateProject = (projectId, payload) => http.put(`${BASE_URL}/${projectId}`, payload)
+const deleteProject = (projectId) => http.delete(`${BASE_URL}/${projectId}`)
+
+// 暴露给业务层使用的 API
+export const projectsApi = {
+  /**
+   * 保持原有用例筛选场景调用方式
+   */
+  getProjectNames,
+
+  /**
+   * 获取项目列表
+   */
+  list(params = {}) {
+    const finalParams = { ...params }
+    Object.keys(finalParams).forEach((key) => {
+      const value = finalParams[key]
+      if (value === '' || value === null || value === undefined) {
+        delete finalParams[key]
+      }
+    })
+    return handleRequest(listProjects, [finalParams], '获取项目列表失败')
+  },
+
+  /**
+   * 获取项目详情
+   */
+  get(projectId) {
+    return handleRequest(getProject, [projectId], '获取项目详情失败')
+  },
+
+  /**
+   * 创建项目
+   */
+  create(payload) {
+    return handleRequest(createProject, [payload], '创建项目失败')
+  },
+
+  /**
+   * 更新项目
+   */
+  update(projectId, payload) {
+    return handleRequest(updateProject, [projectId, payload], '更新项目失败')
+  },
+
+  /**
+   * 删除项目
+   */
+  remove(projectId) {
+    return handleRequest(deleteProject, [projectId], '删除项目失败')
+  }
+}
+
+// 兼容调用：projectsApi.delete
+projectsApi.delete = projectsApi.remove
+
+export default projectsApi

--- a/src/components/Projects/ProjectFormDialog.vue
+++ b/src/components/Projects/ProjectFormDialog.vue
@@ -1,0 +1,305 @@
+<template>
+  <el-dialog
+    v-model="visible"
+    :title="dialogTitle"
+    width="600px"
+    :close-on-click-modal="false"
+    @close="handleClose"
+  >
+    <el-form
+      ref="formRef"
+      :model="formData"
+      :rules="rules"
+      label-width="100px"
+    >
+      <el-form-item label="所属部门" prop="department_id">
+        <el-select
+          v-model="formData.department_id"
+          placeholder="请选择部门"
+          clearable
+          filterable
+          :loading="loadingDepartments"
+        >
+          <el-option
+            v-for="dept in departments"
+            :key="dept.value"
+            :label="dept.label"
+            :value="dept.value"
+          />
+        </el-select>
+      </el-form-item>
+
+      <el-form-item label="项目名称" prop="name">
+        <el-input
+          v-model="formData.name"
+          placeholder="请输入项目名称"
+          maxlength="100"
+          show-word-limit
+          clearable
+        />
+      </el-form-item>
+
+      <el-form-item label="项目编码" prop="code">
+        <el-input
+          v-model="formData.code"
+          placeholder="请输入项目编码（可选）"
+          maxlength="50"
+          show-word-limit
+          clearable
+        />
+      </el-form-item>
+
+      <el-form-item label="负责人" prop="owner_user_id">
+        <el-select
+          v-model="formData.owner_user_id"
+          placeholder="请选择负责人（可选）"
+          clearable
+          filterable
+          :loading="loadingOwners"
+        >
+          <el-option
+            v-for="owner in owners"
+            :key="owner.value"
+            :label="owner.label"
+            :value="owner.value"
+          />
+        </el-select>
+      </el-form-item>
+
+      <el-form-item label="状态" prop="status">
+        <el-select
+          v-model="formData.status"
+          placeholder="请选择状态（可选）"
+          clearable
+          filterable
+        >
+          <el-option
+            v-for="status in mergedStatusOptions"
+            :key="status.value"
+            :label="status.label"
+            :value="status.value"
+          />
+        </el-select>
+      </el-form-item>
+
+      <el-form-item label="项目描述" prop="description">
+        <el-input
+          v-model="formData.description"
+          type="textarea"
+          :rows="4"
+          placeholder="请输入项目描述（可选）"
+          maxlength="500"
+          show-word-limit
+        />
+      </el-form-item>
+    </el-form>
+
+    <template #footer>
+      <div class="dialog-footer">
+        <el-button @click="handleClose">取消</el-button>
+        <el-button type="primary" :loading="submitting" @click="handleSubmit">
+          {{ submitText }}
+        </el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+import { computed, nextTick, reactive, ref } from 'vue'
+import { ElMessage } from 'element-plus'
+import { projectsApi } from '@/api/projects'
+
+const props = defineProps({
+  departments: {
+    type: Array,
+    default: () => []
+  },
+  owners: {
+    type: Array,
+    default: () => []
+  },
+  statusOptions: {
+    type: Array,
+    default: () => []
+  },
+  loadingDepartments: {
+    type: Boolean,
+    default: false
+  },
+  loadingOwners: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emit = defineEmits(['success'])
+
+const visible = ref(false)
+const submitting = ref(false)
+const mode = ref('create')
+const formRef = ref()
+
+const formData = reactive({
+  id: null,
+  department_id: null,
+  name: '',
+  code: '',
+  owner_user_id: null,
+  status: '',
+  statusLabel: '',
+  description: ''
+})
+
+const rules = {
+  department_id: [
+    { required: true, message: '请选择所属部门', trigger: 'change' }
+  ],
+  name: [
+    { required: true, message: '请输入项目名称', trigger: 'blur' },
+    { min: 2, max: 100, message: '项目名称长度在 2 到 100 个字符', trigger: 'blur' }
+  ],
+  code: [
+    { max: 50, message: '项目编码长度不能超过 50 个字符', trigger: 'blur' }
+  ],
+  description: [
+    { max: 500, message: '项目描述长度不能超过 500 个字符', trigger: 'blur' }
+  ]
+}
+
+const dialogTitle = computed(() => (mode.value === 'create' ? '新建项目' : '编辑项目'))
+const submitText = computed(() => (mode.value === 'create' ? '创建' : '保存'))
+
+const mergedStatusOptions = computed(() => {
+  const options = Array.isArray(props.statusOptions) ? [...props.statusOptions] : []
+  const value = formData.status
+  if (value && !options.some((opt) => opt.value === value)) {
+    options.push({ value, label: formData.statusLabel || value })
+  }
+  return options
+})
+
+const loadingDepartments = computed(() => props.loadingDepartments)
+const loadingOwners = computed(() => props.loadingOwners)
+
+const resetForm = () => {
+  Object.assign(formData, {
+    id: null,
+    department_id: null,
+    name: '',
+    code: '',
+    owner_user_id: null,
+    status: '',
+    statusLabel: '',
+    description: ''
+  })
+  formRef.value?.clearValidate()
+}
+
+const openCreate = () => {
+  mode.value = 'create'
+  resetForm()
+  visible.value = true
+}
+
+const openEdit = (project) => {
+  mode.value = 'edit'
+  resetForm()
+  if (project) {
+    formData.id = project.id ?? project.project_id ?? null
+    formData.department_id =
+      project.department_id ?? project.departmentId ?? project.department?.id ?? null
+    formData.name = project.name ?? project.project_name ?? ''
+    formData.code = project.code ?? ''
+    formData.owner_user_id =
+      project.owner_user_id ?? project.ownerUserId ?? project.owner?.id ?? project.owner_user?.id ?? null
+    formData.status = project.status ?? project.project_status ?? project.state ?? ''
+    formData.statusLabel = project.status_label ?? project.statusLabel ?? project.status_text ?? ''
+    formData.description = project.description ?? ''
+  }
+  visible.value = true
+}
+
+const handleClose = () => {
+  visible.value = false
+  nextTick(() => {
+    resetForm()
+  })
+}
+
+const buildPayload = () => {
+  const payload = {
+    department_id: formData.department_id,
+    name: formData.name?.trim()
+  }
+
+  const code = formData.code?.trim()
+  if (code) payload.code = code
+
+  const description = formData.description?.trim()
+  if (description) payload.description = description
+
+  if (formData.owner_user_id) {
+    payload.owner_user_id = formData.owner_user_id
+  }
+
+  const statusValue = formData.status?.trim()
+  if (statusValue) {
+    payload.status = statusValue
+  }
+
+  return payload
+}
+
+const handleSubmit = async () => {
+  try {
+    const valid = await formRef.value?.validate()
+    if (!valid) return
+
+    submitting.value = true
+    const payload = buildPayload()
+
+    let resp
+    if (mode.value === 'create') {
+      resp = await projectsApi.create(payload)
+    } else {
+      const projectId = formData.id
+      if (!projectId) {
+        ElMessage.error('项目信息缺失，无法更新')
+        return
+      }
+      resp = await projectsApi.update(projectId, payload)
+    }
+
+    if (!resp?.success) {
+      return
+    }
+
+    ElMessage.success(mode.value === 'create' ? '项目创建成功' : '项目更新成功')
+    emit('success', {
+      mode: mode.value,
+      data: resp.data ?? null
+    })
+    handleClose()
+  } catch (error) {
+    if (error?.message) {
+      console.error('提交项目表单失败:', error)
+    }
+  } finally {
+    submitting.value = false
+  }
+}
+
+defineExpose({
+  openCreate,
+  openEdit
+})
+</script>
+
+<style scoped>
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+</style>

--- a/src/constants/project.js
+++ b/src/constants/project.js
@@ -1,0 +1,40 @@
+// ================== src/constants/project.js ==================
+
+// 默认的项目状态选项（可根据后端扩展）
+export const PROJECT_STATUS_OPTIONS = [
+  { label: '进行中', value: 'active' },
+  { label: '未开始', value: 'pending' },
+  { label: '暂停中', value: 'on_hold' },
+  { label: '已完成', value: 'completed' },
+  { label: '已归档', value: 'archived' },
+  { label: '已停用', value: 'inactive' }
+]
+
+// 状态与显示文案映射
+export const PROJECT_STATUS_LABEL_MAP = {
+  active: '进行中',
+  pending: '未开始',
+  on_hold: '暂停中',
+  completed: '已完成',
+  archived: '已归档',
+  inactive: '已停用',
+  draft: '草稿'
+}
+
+// 状态与标签颜色映射（Element Plus Tag 类型）
+export const PROJECT_STATUS_TAG_MAP = {
+  active: 'success',
+  completed: 'success',
+  pending: 'warning',
+  on_hold: 'warning',
+  archived: 'info',
+  draft: 'info',
+  inactive: 'danger'
+}
+
+// 获取状态显示文案，带兜底逻辑
+export const resolveProjectStatusLabel = (status, fallbackLabel) => {
+  if (!status && !fallbackLabel) return '-'
+  if (!status) return fallbackLabel
+  return PROJECT_STATUS_LABEL_MAP[status] || fallbackLabel || status || '-'
+}

--- a/src/layouts/AdminLayout.vue
+++ b/src/layouts/AdminLayout.vue
@@ -27,6 +27,10 @@
           <el-icon><Document /></el-icon>
           <span>用例看板</span>
         </el-menu-item>
+        <el-menu-item index="/projects" class="menu-item">
+          <el-icon><FolderOpened /></el-icon>
+          <span>项目管理</span>
+        </el-menu-item>
         <el-menu-item index="/test-cases" class="menu-item">
           <el-icon><Document /></el-icon>
           <span>用例管理</span>
@@ -113,15 +117,16 @@ import { authApi } from '@/api/auth'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import ChangePasswordDialog from '@/components/Auth/ChangePasswordDialog.vue'
 import { 
-  House, 
-  Document, 
-  User, 
-  Management, 
-  Bell, 
-  ArrowDown, 
-  Setting, 
+  House,
+  Document,
+  User,
+  Management,
+  Bell,
+  ArrowDown,
+  Setting,
   SwitchButton,
-  Lock // 新增锁定图标
+  Lock, // 新增锁定图标
+  FolderOpened
 } from '@element-plus/icons-vue'
 
 const route = useRoute()
@@ -138,6 +143,7 @@ const getBreadcrumbTitle = () => {
   const routeMap = {
     '/dashboard': '首页',
     '/plans/board': '用例看板',
+    '/projects': '项目管理',
     '/users': '用户管理',
     '/departments': '部门管理',
     '/test-cases': '用例管理',

--- a/src/pages/Projects/ProjectManagePage.vue
+++ b/src/pages/Projects/ProjectManagePage.vue
@@ -1,0 +1,599 @@
+<template>
+  <div class="project-manage-page">
+    <div class="filter-section">
+      <div class="filter-left">
+        <el-form :model="filters" inline>
+          <el-form-item label="部门">
+            <el-select
+              v-model="filters.department_id"
+              placeholder="全部部门"
+              clearable
+              filterable
+              :loading="optionsLoading.departments"
+              @focus="fetchDepartmentOptionsIfNeeded"
+            >
+              <el-option
+                v-for="dept in departmentOptions"
+                :key="dept.value"
+                :label="dept.label"
+                :value="dept.value"
+              />
+            </el-select>
+          </el-form-item>
+
+          <el-form-item label="项目名称">
+            <el-input
+              v-model="filters.name"
+              placeholder="请输入项目名称"
+              clearable
+              style="width: 200px"
+              @keyup.enter="handleSearch"
+            />
+          </el-form-item>
+
+          <el-form-item label="项目编码">
+            <el-input
+              v-model="filters.code"
+              placeholder="请输入项目编码"
+              clearable
+              style="width: 180px"
+              @keyup.enter="handleSearch"
+            />
+          </el-form-item>
+
+          <el-form-item label="状态">
+            <el-select
+              v-model="filters.status"
+              placeholder="全部状态"
+              clearable
+              filterable
+            >
+              <el-option
+                v-for="status in statusOptions"
+                :key="status.value"
+                :label="status.label"
+                :value="status.value"
+              />
+            </el-select>
+          </el-form-item>
+
+          <el-form-item>
+            <el-button type="primary" @click="handleSearch">搜索</el-button>
+            <el-button @click="handleReset">重置</el-button>
+          </el-form-item>
+        </el-form>
+      </div>
+
+      <div class="filter-right">
+        <el-button type="primary" @click="handleAddProject">
+          <el-icon><Plus /></el-icon>
+          新建项目
+        </el-button>
+      </div>
+    </div>
+
+    <div class="table-section">
+      <el-table
+        v-loading="loading"
+        :data="projectList"
+        stripe
+        style="width: 100%"
+        empty-text="暂无项目数据"
+      >
+        <el-table-column prop="id" label="ID" width="80" align="center" />
+
+        <el-table-column prop="name" label="项目名称" min-width="160" />
+
+        <el-table-column prop="code" label="项目编码" min-width="140">
+          <template #default="{ row }">
+            {{ row.code || '-' }}
+          </template>
+        </el-table-column>
+
+        <el-table-column label="所属部门" min-width="160">
+          <template #default="{ row }">
+            {{ getDepartmentName(row) }}
+          </template>
+        </el-table-column>
+
+        <el-table-column label="负责人" min-width="140">
+          <template #default="{ row }">
+            {{ getOwnerName(row) }}
+          </template>
+        </el-table-column>
+
+        <el-table-column label="状态" width="120" align="center">
+          <template #default="{ row }">
+            <el-tag :type="getStatusTagType(row)" disable-transitions>
+              {{ getStatusLabel(row) }}
+            </el-tag>
+          </template>
+        </el-table-column>
+
+        <el-table-column label="描述" min-width="220">
+          <template #default="{ row }">
+            <el-tooltip
+              v-if="row.description && row.description.length > 40"
+              effect="dark"
+              :content="row.description"
+              placement="top"
+            >
+              <span>{{ row.description.slice(0, 40) }}...</span>
+            </el-tooltip>
+            <span v-else>{{ row.description || '-' }}</span>
+          </template>
+        </el-table-column>
+
+        <el-table-column prop="created_at" label="创建时间" min-width="170">
+          <template #default="{ row }">
+            {{ formatDate(row.created_at) }}
+          </template>
+        </el-table-column>
+
+        <el-table-column prop="updated_at" label="更新时间" min-width="170">
+          <template #default="{ row }">
+            {{ formatDate(row.updated_at) }}
+          </template>
+        </el-table-column>
+
+        <el-table-column label="操作" width="200" fixed="right" align="center">
+          <template #default="{ row }">
+            <el-button type="primary" size="small" @click="handleEditProject(row)">
+              编辑
+            </el-button>
+            <el-button
+              type="danger"
+              size="small"
+              plain
+              @click="handleDeleteProject(row)"
+            >
+              删除
+            </el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <div class="pagination-wrapper">
+        <el-pagination
+          v-model:current-page="pagination.page"
+          v-model:page-size="pagination.pageSize"
+          :total="pagination.total"
+          :page-sizes="[10, 20, 50, 100]"
+          layout="total, sizes, prev, pager, next, jumper"
+          @size-change="handlePageSizeChange"
+          @current-change="handlePageChange"
+        />
+      </div>
+    </div>
+
+    <ProjectFormDialog
+      ref="projectDialogRef"
+      :departments="departmentOptions"
+      :owners="ownerOptions"
+      :status-options="statusOptions"
+      :loading-departments="optionsLoading.departments"
+      :loading-owners="optionsLoading.owners"
+      @success="handleDialogSuccess"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { Plus } from '@element-plus/icons-vue'
+import ProjectFormDialog from '@/components/Projects/ProjectFormDialog.vue'
+import { projectsApi } from '@/api/projects'
+import { departmentService } from '@/api/departments'
+import { userService } from '@/api/users'
+import { formatDateTime } from '@/utils/format'
+import {
+  PROJECT_STATUS_OPTIONS,
+  PROJECT_STATUS_TAG_MAP,
+  resolveProjectStatusLabel
+} from '@/constants/project'
+
+const loading = ref(false)
+const projectList = ref([])
+
+const filters = reactive({
+  department_id: null,
+  name: '',
+  code: '',
+  status: ''
+})
+
+const pagination = reactive({
+  page: 1,
+  pageSize: 20,
+  total: 0
+})
+
+const departmentOptions = ref([])
+const ownerOptions = ref([])
+const extraStatusOptions = ref([])
+
+const optionsLoading = reactive({
+  departments: false,
+  owners: false
+})
+
+const projectDialogRef = ref()
+
+const statusOptions = computed(() => {
+  const base = [...PROJECT_STATUS_OPTIONS]
+  const existing = new Set(base.map((item) => item.value))
+  const extras = Array.isArray(extraStatusOptions.value)
+    ? extraStatusOptions.value.filter((item) => item?.value && !existing.has(item.value))
+    : []
+  return [...base, ...extras]
+})
+
+const formatDate = (value) => (value ? formatDateTime(value) : '')
+
+const hasStatusOption = (value) => {
+  if (!value) return true
+  return (
+    PROJECT_STATUS_OPTIONS.some((item) => item.value === value) ||
+    (Array.isArray(extraStatusOptions.value) &&
+      extraStatusOptions.value.some((item) => item.value === value))
+  )
+}
+
+const ensureStatusOption = (value, label) => {
+  if (!value || hasStatusOption(value)) return
+  const option = { value, label: label || value }
+  const next = Array.isArray(extraStatusOptions.value)
+    ? [...extraStatusOptions.value, option]
+    : [option]
+  extraStatusOptions.value = next
+}
+
+const getProjectStatusValue = (project) =>
+  project?.status ?? project?.project_status ?? project?.state ?? project?.statusValue ?? ''
+
+const getStatusLabel = (project) =>
+  resolveProjectStatusLabel(
+    getProjectStatusValue(project),
+    project?.status_label ?? project?.statusLabel ?? project?.status_text ?? ''
+  )
+
+const getStatusTagType = (project) => {
+  const status = getProjectStatusValue(project)
+  return PROJECT_STATUS_TAG_MAP[status] || 'info'
+}
+
+const getDepartmentName = (project) => {
+  const name =
+    project?.department_name ??
+    project?.departmentName ??
+    project?.department?.name ??
+    project?.department?.title ??
+    project?.department?.display_name
+  return name || '-'
+}
+
+const getOwnerName = (project) => {
+  const name =
+    project?.owner_name ??
+    project?.ownerName ??
+    project?.owner_username ??
+    project?.owner_full_name ??
+    project?.owner?.username ??
+    project?.owner?.name ??
+    project?.owner_user?.username ??
+    project?.owner_user?.name
+  return name || '-'
+}
+
+const getProjectId = (project) => project?.id ?? project?.project_id ?? null
+
+const ensureStatusOptionFromProject = (project) => {
+  const status = getProjectStatusValue(project)
+  if (!status) return
+  const label = getStatusLabel(project)
+  ensureStatusOption(status, label)
+}
+
+const normalizeProjectListResponse = (data) => {
+  if (Array.isArray(data)) {
+    return { items: data, total: data.length }
+  }
+  if (!data || typeof data !== 'object') {
+    return { items: [], total: 0 }
+  }
+  if (Array.isArray(data.items)) {
+    return {
+      items: data.items,
+      total: Number.isFinite(data.total) ? data.total : data.items.length
+    }
+  }
+  if (Array.isArray(data.list)) {
+    return {
+      items: data.list,
+      total: Number.isFinite(data.total) ? data.total : data.list.length
+    }
+  }
+  if (Array.isArray(data.projects)) {
+    return {
+      items: data.projects,
+      total: Number.isFinite(data.total) ? data.total : data.projects.length
+    }
+  }
+  return {
+    items: [],
+    total: Number.isFinite(data.total) ? data.total : 0
+  }
+}
+
+const fetchProjectList = async () => {
+  loading.value = true
+  try {
+    const params = {
+      page: pagination.page,
+      page_size: pagination.pageSize,
+      order: 'desc'
+    }
+
+    if (filters.department_id) params.department_id = filters.department_id
+    if (filters.name?.trim()) params.name = filters.name.trim()
+    if (filters.code?.trim()) params.code = filters.code.trim()
+    if (filters.status) params.status = filters.status
+
+    const resp = await projectsApi.list(params)
+    if (!resp?.success) {
+      projectList.value = []
+      pagination.total = 0
+      return
+    }
+
+    const normalized = normalizeProjectListResponse(resp.data)
+    projectList.value = normalized.items || []
+    pagination.total = Number.isFinite(normalized.total)
+      ? normalized.total
+      : (normalized.items || []).length
+
+    updateStatusOptionsFromItems(normalized.items || [])
+  } catch (error) {
+    console.error('获取项目列表失败:', error)
+    ElMessage.error('获取项目列表失败')
+  } finally {
+    loading.value = false
+  }
+}
+
+const updateStatusOptionsFromItems = (items) => {
+  if (!Array.isArray(items)) return
+  const additions = []
+  items.forEach((item) => {
+    const status = getProjectStatusValue(item)
+    if (!status || hasStatusOption(status)) return
+    additions.push({ value: status, label: getStatusLabel(item) })
+  })
+  if (!additions.length) return
+  const merged = Array.isArray(extraStatusOptions.value) ? [...extraStatusOptions.value] : []
+  const existing = new Set(merged.map((item) => item.value))
+  additions.forEach((item) => {
+    if (!existing.has(item.value)) {
+      merged.push(item)
+      existing.add(item.value)
+    }
+  })
+  extraStatusOptions.value = merged
+}
+
+const fetchDepartmentOptions = async () => {
+  optionsLoading.departments = true
+  try {
+    const resp = await departmentService.list({ page: 1, page_size: 1000 })
+    if (!resp?.success) return
+    const items = resp.data?.items || resp.data?.list || []
+    if (!Array.isArray(items)) {
+      departmentOptions.value = []
+      return
+    }
+
+    const uniqueMap = new Map()
+    items.forEach((dept) => {
+      const value = dept.id ?? dept.department_id ?? dept.dept_id ?? dept.departmentId ?? null
+      if (value === null || value === undefined) return
+      const label =
+        dept.name ??
+        dept.department_name ??
+        dept.title ??
+        dept.display_name ??
+        `部门 #${dept.id ?? dept.department_id ?? ''}`
+      uniqueMap.set(value, { value, label })
+    })
+    departmentOptions.value = Array.from(uniqueMap.values())
+  } catch (error) {
+    console.error('获取部门数据失败:', error)
+  } finally {
+    optionsLoading.departments = false
+  }
+}
+
+const fetchDepartmentOptionsIfNeeded = async () => {
+  if (departmentOptions.value.length) return
+  await fetchDepartmentOptions()
+}
+
+const fetchOwnerOptions = async () => {
+  optionsLoading.owners = true
+  try {
+    const resp = await userService.getList({ page: 1, page_size: 1000 })
+    if (!resp?.success) return
+    const items = resp.data?.items || resp.data?.list || []
+    if (!Array.isArray(items)) {
+      ownerOptions.value = []
+      return
+    }
+
+    const uniqueMap = new Map()
+    items.forEach((user) => {
+      const value = user.id ?? user.user_id ?? user.userId ?? null
+      if (!value && value !== 0) return
+      const label =
+        user.username ||
+        user.name ||
+        user.full_name ||
+        user.email ||
+        `用户#${user.id ?? user.user_id ?? ''}`
+      uniqueMap.set(value, { value, label })
+    })
+    ownerOptions.value = Array.from(uniqueMap.values())
+  } catch (error) {
+    console.error('获取用户数据失败:', error)
+  } finally {
+    optionsLoading.owners = false
+  }
+}
+
+const fetchOwnerOptionsIfNeeded = async () => {
+  if (ownerOptions.value.length) return
+  await fetchOwnerOptions()
+}
+
+const ensureReferenceData = async () => {
+  await Promise.all([fetchDepartmentOptionsIfNeeded(), fetchOwnerOptionsIfNeeded()])
+}
+
+const handleSearch = () => {
+  pagination.page = 1
+  fetchProjectList()
+}
+
+const handleReset = () => {
+  Object.assign(filters, {
+    department_id: null,
+    name: '',
+    code: '',
+    status: ''
+  })
+  pagination.page = 1
+  fetchProjectList()
+}
+
+const handlePageChange = (page) => {
+  pagination.page = page
+  fetchProjectList()
+}
+
+const handlePageSizeChange = (size) => {
+  pagination.pageSize = size
+  pagination.page = 1
+  fetchProjectList()
+}
+
+const handleAddProject = async () => {
+  await ensureReferenceData()
+  projectDialogRef.value?.openCreate()
+}
+
+const handleEditProject = async (project) => {
+  await ensureReferenceData()
+  ensureStatusOptionFromProject(project)
+  projectDialogRef.value?.openEdit(project)
+}
+
+const handleDeleteProject = async (project) => {
+  const projectId = getProjectId(project)
+  if (!projectId) {
+    ElMessage.error('无法识别要删除的项目')
+    return
+  }
+
+  const projectName = project?.name ?? project?.project_name ?? `ID ${projectId}`
+
+  try {
+    await ElMessageBox.confirm(
+      `确定要删除项目 “${projectName}” 吗？`,
+      '删除确认',
+      {
+        confirmButtonText: '删除',
+        cancelButtonText: '取消',
+        type: 'warning'
+      }
+    )
+  } catch (error) {
+    if (error !== 'cancel' && error !== 'close') {
+      console.error('删除项目操作被中断:', error)
+    }
+    return
+  }
+
+  try {
+    const resp = await projectsApi.remove(projectId)
+    if (!resp?.success) return
+
+    ElMessage.success('项目删除成功')
+    if (projectList.value.length === 1 && pagination.page > 1) {
+      pagination.page -= 1
+    }
+    await fetchProjectList()
+  } catch (error) {
+    console.error('删除项目失败:', error)
+    ElMessage.error('删除项目失败')
+  }
+}
+
+const handleDialogSuccess = (payload) => {
+  if (payload?.data) {
+    ensureStatusOptionFromProject(payload.data)
+  }
+  fetchProjectList()
+}
+
+onMounted(() => {
+  fetchDepartmentOptionsIfNeeded()
+  fetchProjectList()
+})
+</script>
+
+<style scoped>
+.project-manage-page {
+  padding: 20px;
+  background: #f5f7fa;
+  min-height: 100vh;
+}
+
+.filter-section {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 20px;
+  padding: 20px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+.filter-left {
+  flex: 1;
+}
+
+.filter-right {
+  margin-left: 20px;
+  display: flex;
+  align-items: flex-start;
+  padding-top: 2px;
+}
+
+.table-section {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  padding: 20px;
+}
+
+.pagination-wrapper {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+}
+
+:deep(.el-form--inline .el-form-item) {
+  margin-right: 16px;
+  margin-bottom: 8px;
+}
+</style>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -22,6 +22,15 @@ export const routes = [
         meta: { title: '用例看板' }
       },
       {
+        path: 'projects',
+        name: 'ProjectManage',
+        component: () => import('../pages/Projects/ProjectManagePage.vue'),
+        meta: {
+          title: '项目管理',
+          requiresAuth: true
+        }
+      },
+      {
         path: 'users',
         name: 'userManage',
         component: () => import('../pages/Users/UserManagePage.vue'),


### PR DESCRIPTION
## Summary
- add REST helpers and constants for project resources
- build a project management page with filtering, pagination, and CRUD dialog support
- wire the new page into the sidebar navigation and router

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c909db79b48331ae3a6254f0976dad