### PR TITLE
feat: allow editing plan testers and disable archived edits

### DIFF
--- a/src/components/TestPlans/TestPlanEditDialog.vue
+++ b/src/components/TestPlans/TestPlanEditDialog.vue
@@ -61,6 +61,26 @@
         />
       </el-form-item>
 
+      <el-form-item label="测试人员" prop="tester_user_ids">
+        <el-select
+          v-model="formData.tester_user_ids"
+          multiple
+          collapse-tags
+          collapse-tags-tooltip
+          placeholder="请选择测试人员"
+          :disabled="!formData.department_id"
+          :loading="optionsLoading.testers"
+          filterable
+        >
+          <el-option
+            v-for="user in testerOptions"
+            :key="user.value"
+            :label="user.label"
+            :value="user.value"
+          />
+        </el-select>
+      </el-form-item>
+
       <el-form-item label="计划描述">
         <el-input
           v-model="formData.description"
@@ -88,6 +108,7 @@
 import { computed, nextTick, reactive, ref } from 'vue'
 import { ElMessage } from 'element-plus'
 import { testPlansApi } from '@/api/testPlans'
+import { departmentService } from '@/api/departments'
 
 const props = defineProps({
   statusOptions: {
@@ -104,12 +125,14 @@ const formRef = ref()
 
 const formData = reactive({
   id: null,
+  department_id: null,
   project_name: '',
   name: '',
   status: '',
   start_date: '',
   end_date: '',
-  description: ''
+  description: '',
+  tester_user_ids: []
 })
 
 const rules = {
@@ -119,6 +142,9 @@ const rules = {
   ],
   status: [
     { required: true, message: '请选择计划状态', trigger: 'change' }
+  ],
+  tester_user_ids: [
+    { type: 'array', required: true, message: '请选择测试人员', trigger: 'change' }
   ]
 }
 
@@ -130,33 +156,140 @@ const mergedStatusOptions = computed(() => {
   return base
 })
 
+const testerOptions = ref([])
+
+const optionsLoading = reactive({
+  testers: false
+})
+
 const dialogTitle = computed(() => '编辑测试计划')
 
 const resetForm = () => {
   Object.assign(formData, {
     id: null,
+    department_id: null,
     project_name: '',
     name: '',
     status: '',
     start_date: '',
     end_date: '',
-    description: ''
+    description: '',
+    tester_user_ids: []
   })
+  testerOptions.value = []
   formRef.value?.clearValidate()
+}
+
+const buildTesterOption = (tester) => {
+  if (!tester) return null
+  const rawId =
+    tester.user_id ||
+    tester.userId ||
+    tester.tester_id ||
+    tester.tester?.id ||
+    tester.id
+  if (rawId === undefined || rawId === null || rawId === '') return null
+  const userId = Number(rawId)
+  if (Number.isNaN(userId)) return null
+  const label =
+    tester.tester?.username ||
+    tester.username ||
+    tester.name ||
+    tester.tester_name ||
+    `用户#${userId}`
+  return { value: userId, label }
+}
+
+const mergeTesterOptions = (options = []) => {
+  const map = new Map()
+  const existing = Array.isArray(testerOptions.value) ? testerOptions.value : []
+  existing.forEach((item) => {
+    if (!item || item.value === undefined || item.value === null) return
+    const value = Number(item.value)
+    if (Number.isNaN(value)) return
+    map.set(value, item.label || `用户#${value}`)
+  })
+  options.forEach((item) => {
+    if (!item || item.value === undefined || item.value === null) return
+    const value = Number(item.value)
+    if (Number.isNaN(value)) return
+    if (!map.has(value)) {
+      map.set(value, item.label || `用户#${value}`)
+    }
+  })
+  testerOptions.value = Array.from(map.entries()).map(([value, label]) => ({
+    value,
+    label
+  }))
+}
+
+const fetchTesterOptions = async (departmentId) => {
+  if (!departmentId) return
+  optionsLoading.testers = true
+  try {
+    const response = await departmentService.listMembers(departmentId, { page: 1, page_size: 1000 })
+    if (!response?.success) return
+    const items = response.data?.items || response.data?.list || []
+    const options = items
+      .map((member) => {
+        if (!member) return null
+        const rawId =
+          member.user_id ||
+          member.userId ||
+          member.id ||
+          member.user?.id
+        if (rawId === undefined || rawId === null || rawId === '') return null
+        const userId = Number(rawId)
+        if (Number.isNaN(userId)) return null
+        const user = member.user || {}
+        const label =
+          member.username ||
+          member.name ||
+          user.username ||
+          user.name ||
+          `用户#${userId}`
+        return { value: userId, label }
+      })
+      .filter(Boolean)
+    mergeTesterOptions(options)
+  } catch (error) {
+    console.error('获取测试人员失败:', error)
+  } finally {
+    optionsLoading.testers = false
+  }
 }
 
 const open = (plan) => {
   resetForm()
   if (plan) {
+    const departmentId = Number(
+      plan.department_id ||
+        plan.departmentId ||
+        plan.project?.department_id ||
+        plan.project?.departmentId ||
+        plan.project?.department?.id ||
+        plan.department?.id
+    )
+    const testers = Array.isArray(plan.testers) ? plan.testers : []
+    const initialTesterOptions = testers
+      .map((tester) => buildTesterOption(tester))
+      .filter(Boolean)
+    const testerIds = initialTesterOptions.map((item) => item.value)
     Object.assign(formData, {
       id: plan.id,
+      department_id: departmentId || null,
       project_name: plan.project_name || '',
       name: plan.name || '',
       status: plan.status || '',
       start_date: plan.start_date || '',
       end_date: plan.end_date || '',
-      description: plan.description || ''
+      description: plan.description || '',
+      tester_user_ids: testerIds
     })
+    mergeTesterOptions(initialTesterOptions)
+    if (departmentId) {
+      fetchTesterOptions(departmentId)
+    }
   }
   visible.value = true
   nextTick(() => formRef.value?.clearValidate())
@@ -172,7 +305,8 @@ const handleSubmit = () => {
         description: formData.description || undefined,
         status: formData.status,
         start_date: formData.start_date || null,
-        end_date: formData.end_date || null
+        end_date: formData.end_date || null,
+        tester_user_ids: formData.tester_user_ids
       }
       const response = await testPlansApi.update(formData.id, payload)
       if (response?.success) {

--- a/src/pages/TestPlans/TestPlanListPage.vue
+++ b/src/pages/TestPlans/TestPlanListPage.vue
@@ -167,7 +167,23 @@
 
         <el-table-column label="操作" width="180" fixed="right" align="center">
           <template #default="{ row }">
-            <el-button type="primary" size="small" @click="handleEdit(row)">编辑</el-button>
+            <el-tooltip
+              v-if="isPlanArchived(row)"
+              content="已归档的计划不可编辑"
+              placement="top"
+            >
+              <span class="disabled-tooltip-wrapper">
+                <el-button type="primary" size="small" disabled>编辑</el-button>
+              </span>
+            </el-tooltip>
+            <el-button
+              v-else
+              type="primary"
+              size="small"
+              @click="handleEdit(row)"
+            >
+              编辑
+            </el-button>
             <el-button type="info" size="small" plain @click="viewDetail(row)">详情</el-button>
           </template>
         </el-table-column>
@@ -356,6 +372,10 @@ const handleEdit = async (row) => {
     ElMessage.warning('无法识别该测试计划')
     return
   }
+  if (isPlanArchived(row)) {
+    ElMessage.info('已归档的测试计划不可编辑')
+    return
+  }
   if (!projectOptions.value.length) {
     await fetchProjects()
   }
@@ -387,6 +407,8 @@ const handleCreateSuccess = () => {
 
 const resolveStatusTag = (status) => TEST_PLAN_STATUS_TAG_MAP[status] || 'info'
 const resolveStatusLabel = (status) => resolvePlanStatusLabel(status)
+
+const isPlanArchived = (plan) => plan?.status === 'archived'
 
 watch(
   () => filters.department_id,
@@ -472,5 +494,13 @@ onMounted(() => {
   display: flex;
   justify-content: flex-end;
   margin-top: 16px;
+}
+
+.disabled-tooltip-wrapper {
+  display: inline-block;
+}
+
+.disabled-tooltip-wrapper .el-button {
+  pointer-events: none;
 }
 </style>


### PR DESCRIPTION
## Summary
- allow editing a plan's tester assignments from the edit dialog and sync tester options from the department roster
- submit tester selections with plan updates so backend changes take effect
- block editing for archived plans by disabling the edit action and showing a tooltip explanation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca8dca9ba88331956a97af97ba48f4