### PR TITLE
feat: 支持目录复制与用例导入

### DIFF
--- a/src/api/testCases.js
+++ b/src/api/testCases.js
@@ -63,6 +63,11 @@ function copyTestCase(caseId, payload) {
   return http.post(`/api/test-cases/${caseId}/copy`, payload)
 }
 
+// 批量导入用例 POST /api/test-cases/batch-import
+function batchImportTestCases(payload, config = {}) {
+  return http.post('/api/test-cases/batch-import', payload, config)
+}
+
 // 用例历史 GET /api/test-cases/:case_id/history
 function getTestCaseHistory(caseId, params = {}) {
   return http.get(`/api/test-cases/${caseId}/history`, { params })
@@ -102,6 +107,21 @@ export const testCaseService = {
 
   /** 复制用例 */
   copy: (caseId, payload) => handleRequest(copyTestCase, [caseId, payload], '复制用例失败'),
+
+  /** 通过文件导入用例 */
+  batchImportFromFile: ({ department_id: departmentId, group_id: groupId, file }) => {
+    if (!departmentId) {
+      return Promise.resolve({ success: false, message: '部门ID不能为空', data: null })
+    }
+
+    const formData = new FormData()
+    formData.append('department_id', departmentId)
+    if (groupId) formData.append('group_id', groupId)
+    formData.append('file', file)
+
+    const config = { headers: { 'Content-Type': 'multipart/form-data' } }
+    return handleRequest(batchImportTestCases, [formData, config], '导入用例失败')
+  },
 
   /** 获取用例历史 */
   history: (caseId, limit) => {

--- a/src/pages/TestCases/components/CaseGroupTree.vue
+++ b/src/pages/TestCases/components/CaseGroupTree.vue
@@ -46,6 +46,14 @@
                 type="primary"
                 size="small"
                 text
+                @click.stop="onCopyGroup(data)"
+              >
+                <el-icon><CopyDocument /></el-icon>
+              </el-button>
+              <el-button
+                type="primary"
+                size="small"
+                text
                 @click.stop="onEditGroup(data)"
               >
                 <el-icon><Edit /></el-icon>
@@ -68,7 +76,7 @@
 
 <script setup>
 import { ref, watch, nextTick } from 'vue'
-import { Plus, Edit, Delete, Folder, FolderOpened } from '@element-plus/icons-vue'
+import { Plus, Edit, Delete, Folder, FolderOpened, CopyDocument } from '@element-plus/icons-vue'
 import { ElMessageBox } from 'element-plus'
 import { caseGroupService } from '@/api/caseGroups'
 
@@ -170,6 +178,27 @@ const onDeleteGroup = async (data) => {
   } catch {}
 }
 
+const onCopyGroup = async (data) => {
+  try {
+    const { value } = await ElMessageBox.prompt('请输入复制后的分组名称', '复制分组', {
+      inputValue: `${data.name} - 副本`,
+      inputValidator: v => !!v || '名称不能为空'
+    })
+    const resp = await caseGroupService.copy(data.id, { new_name: value })
+    if (resp.success) {
+      await fetchGroups()
+      await nextTick()
+      const newGroupId = resp.data?.id ?? data.id
+      selectedGroupId.value = newGroupId
+      treeRef.value?.setCurrentKey(newGroupId)
+      if (resp.data?.id) {
+        emit('group-select', newGroupId)
+        emit('select', newGroupId)
+      }
+    }
+  } catch {}
+}
+
 const clearSelection = () => {
   selectedGroupId.value = null
   treeRef.value?.setCurrentKey(null)
@@ -209,7 +238,7 @@ defineExpose({ clearSelection, refresh, fetchGroups: refresh })
 .tree-node {
   position: relative;
   display: flex; align-items: center; width: 100%;
-  padding-right: 76px;
+  padding-right: 108px;
 }
 
 .node-content {


### PR DESCRIPTION
## Summary
- 为用例分组树新增复制功能按钮，调用已有接口创建目录副本并保持选中状态
- 在用例管理页新增用例导入弹窗，支持选择目标目录并上传文件触发批量导入
- 新增 testCaseService.batchImportFromFile 方法，使用 multipart/form-data 调用后台导入接口

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd2142191883318b0a3cb454f2bbb0