### PR TITLE
feat: support encrypted execution time and attachments

### DIFF
--- a/src/components/TestPlans/TestPlanResultDialog.vue
+++ b/src/components/TestPlans/TestPlanResultDialog.vue
@@ -31,6 +31,26 @@
         </el-select>
       </el-form-item>
 
+      <el-form-item label="开始时间" prop="execution_start_time">
+        <el-date-picker
+          v-model="formData.execution_start_time"
+          type="datetime"
+          placeholder="请选择执行开始时间"
+          :disabled-date="disableFutureDate"
+          style="width: 100%"
+        />
+      </el-form-item>
+
+      <el-form-item label="结束时间" prop="execution_end_time">
+        <el-date-picker
+          v-model="formData.execution_end_time"
+          type="datetime"
+          placeholder="请选择执行结束时间"
+          :disabled-date="disableFutureDate"
+          style="width: 100%"
+        />
+      </el-form-item>
+
       <el-form-item label="耗时 (毫秒)">
         <el-input-number
           v-model="formData.duration_ms"
@@ -72,6 +92,25 @@
           show-word-limit
         />
       </el-form-item>
+
+      <el-form-item label="执行附件">
+        <el-upload
+          class="attachment-uploader"
+          action=""
+          :auto-upload="false"
+          multiple
+          :file-list="attachmentList"
+          :on-change="handleAttachmentChange"
+          :on-remove="handleAttachmentRemove"
+          :limit="10"
+          :on-exceed="handleAttachmentExceed"
+        >
+          <el-button type="primary">选择文件</el-button>
+          <template #tip>
+            <div class="el-upload__tip">支持上传多个附件，单个文件大小建议不超过 20MB</div>
+          </template>
+        </el-upload>
+      </el-form-item>
     </el-form>
 
     <template #footer>
@@ -90,6 +129,7 @@ import { computed, nextTick, reactive, ref } from 'vue'
 import { ElMessage } from 'element-plus'
 import { testPlansApi } from '@/api/testPlans'
 import { EXECUTION_RESULT_OPTIONS, resolveExecutionResultLabel } from '@/constants/testPlan'
+import { encryptTimestamp } from '@/utils/timestampEncryption'
 
 const props = defineProps({
   planId: {
@@ -113,13 +153,111 @@ const formData = reactive({
   remark: '',
   failure_reason: '',
   bug_ref: '',
-  duration_ms: null
+  duration_ms: null,
+  execution_start_time: null,
+  execution_end_time: null
 })
 
 const rules = {
   result: [
     { required: true, message: '请选择执行结果', trigger: 'change' }
+  ],
+  execution_start_time: [
+    { required: true, message: '请选择执行开始时间', trigger: 'change' },
+    { validator: validateTimeOrder, trigger: 'change' }
+  ],
+  execution_end_time: [
+    { required: true, message: '请选择执行结束时间', trigger: 'change' },
+    { validator: validateTimeOrder, trigger: 'change' }
   ]
+}
+
+const attachmentList = ref([])
+
+function validateTimeOrder(rule, value, callback) {
+  const start = formData.execution_start_time
+  const end = formData.execution_end_time
+  if (!start || !end) {
+    callback()
+    return
+  }
+  const startMs = new Date(start).getTime()
+  const endMs = new Date(end).getTime()
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) {
+    callback(new Error('请选择有效的时间'))
+    return
+  }
+  if (endMs < startMs) {
+    callback(new Error('结束时间不能早于开始时间'))
+    return
+  }
+  callback()
+}
+
+const disableFutureDate = (date) => {
+  return date.getTime() > Date.now()
+}
+
+const normalizeExistingAttachment = (attachment) => ({
+  uid: `existing-${attachment.id ?? attachment.file_path ?? attachment.file_name}-${Math.random().toString(36).slice(2, 8)}`,
+  name: attachment.file_name,
+  status: 'success',
+  isExisting: true,
+  stored_file_name: attachment.stored_file_name,
+  file_path: attachment.file_path,
+  size: attachment.size,
+  uploaded_by: attachment.uploaded_by,
+  url: attachment.url || attachment.file_url || attachment.file_path
+})
+
+const handleAttachmentChange = (uploadFile, uploadFiles) => {
+  attachmentList.value = uploadFiles
+}
+
+const handleAttachmentRemove = (uploadFile, uploadFiles) => {
+  attachmentList.value = uploadFiles
+}
+
+const handleAttachmentExceed = () => {
+  ElMessage.warning('最多只能上传 10 个附件，请先删除部分文件')
+}
+
+const resetAttachments = (execution) => {
+  const attachments = Array.isArray(execution?.attachments) ? execution.attachments : []
+  attachmentList.value = attachments.map((item) => normalizeExistingAttachment(item))
+}
+
+const readFileAsDataUrl = (file) => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.onerror = () => reject(new Error('附件读取失败'))
+    reader.readAsDataURL(file)
+  })
+}
+
+const prepareAttachmentsPayload = async () => {
+  const results = []
+  for (const item of attachmentList.value) {
+    if (item.isExisting) {
+      results.push({
+        file_name: item.name,
+        stored_file_name: item.stored_file_name,
+        file_path: item.file_path,
+        size: item.size,
+        uploaded_by: item.uploaded_by
+      })
+      continue
+    }
+    if (!item.raw) continue
+    const content = await readFileAsDataUrl(item.raw)
+    results.push({
+      file_name: item.name,
+      content,
+      size: item.size ?? item.raw.size
+    })
+  }
+  return results
 }
 
 const executionSummary = computed(() => {
@@ -149,8 +287,11 @@ const open = (execution) => {
     remark: execution?.remark || '',
     failure_reason: execution?.failure_reason || '',
     bug_ref: execution?.bug_ref || '',
-    duration_ms: execution?.duration_ms ?? null
+    duration_ms: execution?.duration_ms ?? null,
+    execution_start_time: execution?.execution_start_time ? new Date(execution.execution_start_time) : null,
+    execution_end_time: execution?.execution_end_time ? new Date(execution.execution_end_time) : null
   })
+  resetAttachments(execution)
   visible.value = true
   nextTick(() => formRef.value?.clearValidate())
 }
@@ -160,6 +301,25 @@ const handleSubmit = () => {
     if (!valid) return
     submitting.value = true
     try {
+      if (!formData.execution_start_time || !formData.execution_end_time) {
+        ElMessage.error('请填写完整的开始和结束时间')
+        return
+      }
+      const startDate = new Date(formData.execution_start_time)
+      const endDate = new Date(formData.execution_end_time)
+      if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+        ElMessage.error('请选择有效的执行时间')
+        return
+      }
+      if (endDate.getTime() < startDate.getTime()) {
+        ElMessage.error('结束时间不能早于开始时间')
+        return
+      }
+      const [encryptedStart, encryptedEnd] = await Promise.all([
+        encryptTimestamp(startDate),
+        encryptTimestamp(endDate)
+      ])
+      const attachmentsPayload = await prepareAttachmentsPayload()
       const payload = {
         plan_case_id: formData.plan_case_id,
         device_model_id: formData.device_model_id,
@@ -168,18 +328,38 @@ const handleSubmit = () => {
         remark: formData.remark || undefined,
         failure_reason: formData.failure_reason || undefined,
         bug_ref: formData.bug_ref || undefined,
-        duration_ms: formData.duration_ms ?? undefined
+        duration_ms: formData.duration_ms ?? undefined,
+        execution_start_time: encryptedStart,
+        execution_end_time: encryptedEnd,
+        attachments: attachmentsPayload
       }
       const response = await testPlansApi.recordResult(props.planId, payload)
       if (response?.success) {
-        const resultData = response.data || {
+        const sanitizedAttachments = attachmentsPayload.map((item) => {
+          if (item.content) {
+            return {
+              file_name: item.file_name,
+              size: item.size
+            }
+          }
+          return { ...item }
+        })
+        const fallbackResult = {
           ...payload,
-          executed_at: new Date().toISOString()
+          execution_start_time: startDate.toISOString(),
+          execution_end_time: endDate.toISOString(),
+          executed_at: new Date().toISOString(),
+          attachments: sanitizedAttachments
         }
+        const resultData = response.data || fallbackResult
         ElMessage.success(response.message || `已记录结果：${resolveExecutionResultLabel(formData.result)}`)
         emit('success', resultData)
         visible.value = false
       }
+    } catch (error) {
+      console.error(error)
+      const message = error?.message || '记录执行结果失败'
+      ElMessage.error(message)
     } finally {
       submitting.value = false
     }
@@ -188,6 +368,7 @@ const handleSubmit = () => {
 
 const handleClose = () => {
   visible.value = false
+  attachmentList.value = []
 }
 
 defineExpose({
@@ -200,5 +381,9 @@ defineExpose({
   display: flex;
   justify-content: flex-end;
   gap: 12px;
+}
+
+.attachment-uploader {
+  width: 100%;
 }
 </style>

--- a/src/utils/timestampEncryption.js
+++ b/src/utils/timestampEncryption.js
@@ -1,0 +1,84 @@
+const textEncoder = new TextEncoder()
+
+function getSecretKey() {
+  const secret = import.meta.env.VITE_TIMESTAMP_SECRET_KEY
+  if (!secret) {
+    throw new Error('缺少时间戳加密所需的密钥配置 VITE_TIMESTAMP_SECRET_KEY')
+  }
+  return secret
+}
+
+function bufferToHex(buffer) {
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function base64UrlEncode(plainText) {
+  if (typeof window !== 'undefined' && window.btoa) {
+    const encoded = window.btoa(unescape(encodeURIComponent(plainText)))
+    return encoded.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+  }
+  return Buffer.from(plainText, 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '')
+}
+
+async function generateHmacHex(message) {
+  const secret = getSecretKey()
+  if (globalThis.crypto?.subtle) {
+    const key = await globalThis.crypto.subtle.importKey(
+      'raw',
+      textEncoder.encode(secret),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign']
+    )
+    const signature = await globalThis.crypto.subtle.sign('HMAC', key, textEncoder.encode(message))
+    return bufferToHex(signature)
+  }
+
+  const { createHmac } = await import('crypto')
+  return createHmac('sha256', secret).update(message).digest('hex')
+}
+
+function normalizeTimestampInput(input) {
+  if (input === null || input === undefined) {
+    throw new Error('时间参数不能为空')
+  }
+
+  if (input instanceof Date) {
+    if (Number.isNaN(input.getTime())) {
+      throw new Error('时间参数不是有效的日期')
+    }
+    return input.getTime()
+  }
+
+  if (typeof input === 'number') {
+    if (!Number.isFinite(input)) {
+      throw new Error('时间参数不是有效的毫秒时间戳')
+    }
+    return Math.floor(input)
+  }
+
+  const parsed = new Date(input)
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('时间参数不是有效的日期格式')
+  }
+  return parsed.getTime()
+}
+
+export async function encryptTimestamp(input) {
+  const millis = normalizeTimestampInput(input)
+  if (millis < 0) {
+    throw new Error('时间参数不能为负数')
+  }
+  const timestampPart = Math.floor(millis).toString()
+  const signature = await generateHmacHex(timestampPart)
+  const plainText = `${timestampPart}.${signature}`
+  return base64UrlEncode(plainText)
+}
+
+export default encryptTimestamp


### PR DESCRIPTION
## Summary
- add a timestamp encryption utility that follows the backend HMAC + base64 scheme
- require start/end execution times, encrypt them before submission, and add attachment upload support in the result dialog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5031599648331a54d7c4648ccdbe3